### PR TITLE
oyster generate-config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Run the following command and answer the question prompts.
 npx oyster-package-generator init
 ```
 
-Please note if you plan on using Oyster a lot you should globally install it for speed purposes. `npx` can be quite slow since it doesn't cache.
+Please note if you plan on using Oyster a lot (or on [Windows 10](#windows-10-troubleshooting)) you should globally install it. `npx` can be quite slow since it doesn't cache.
 
 ```bash
 npm install -g oyster-package-generator
@@ -110,6 +110,7 @@ This package comes with a convenient feature to upgrade an older Oyster project 
 * Make sure all changes are checked in, this will delete files
 * After the process runs, check your Git diffs to make sure nothing was lost
 * If you're upgrading from Travis CI to GitHub Actions you'll need to provide a new `NPM_TOKEN` in your repo's [secrets](https://docs.github.com/en/actions/reference/encrypted-secrets)
+* If you do not have a `.oyster.json` file (older projects), generate one with the [generate-config](#generating-a-config) command
 
 When ready, use this command to trigger the upgrade.
 
@@ -117,7 +118,15 @@ When ready, use this command to trigger the upgrade.
 npx oyster-package-generator upgrade
 ```
 
-#### GitHub Protected Branches
+#### Generating a config
+
+If you're on Oyster v1.X or v2.0, you'll need to generate a config file before running the `upgrade` command. Configs are new as of version `v2.1.0`. Generate a config file by running the following.
+
+```bash
+npx oyster-package-generator generate-config
+```
+
+### GitHub Protected Branches
 
 Due to a known bug with GitHub Action commits, it's not recommended to add special requirements to a `master` protected branch. You can still protect `master`, but special requirements will result in crashing the Semantic Release bot that auto deploys releases.
 

--- a/src/commands/commands-controller.spec.ts
+++ b/src/commands/commands-controller.spec.ts
@@ -1,4 +1,5 @@
 import CommandController from './commands-controller';
+import CommandGenerateConfig from './generate-config/command-generate-config';
 import CommandInstall from './install/command-install';
 import CommandUpgrade from './upgrade/command-upgrade';
 
@@ -13,6 +14,10 @@ jest.mock('./upgrade/command-upgrade');
 // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
 const mockCommandUpgrade: jest.Mock<any> = CommandUpgrade as any;
 
+jest.mock('./generate-config/command-generate-config');
+// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+const mockCommandGenerateConfig: jest.Mock<any> = CommandGenerateConfig as any;
+
 describe('CommandController class', () => {
   const setup = () => {
     const instanceCommandInstall = { run: jest.fn() };
@@ -21,12 +26,18 @@ describe('CommandController class', () => {
     const instanceCommandUpgrade = { run: jest.fn() };
     mockCommandUpgrade.mockImplementation(() => instanceCommandUpgrade);
 
+    const instanceCommandGenerateConfig = { run: jest.fn() };
+    mockCommandGenerateConfig.mockImplementation(
+      () => instanceCommandGenerateConfig,
+    );
+
     jest.spyOn(console, 'log').mockImplementation();
 
     return {
       commands: new CommandController(),
       instanceCommandInstall,
       instanceCommandUpgrade,
+      instanceCommandGenerateConfig,
     };
   };
 
@@ -91,6 +102,17 @@ describe('CommandController class', () => {
       commands.run(argument);
 
       expect(console.log).toHaveBeenCalled();
+    });
+  });
+
+  describe('generate-config command', () => {
+    it('should run the command', () => {
+      const argument = 'generate-config';
+
+      const { commands, instanceCommandGenerateConfig } = setup();
+      commands.run(argument);
+
+      expect(instanceCommandGenerateConfig.run).toHaveBeenCalled();
     });
   });
 });

--- a/src/commands/commands-controller.ts
+++ b/src/commands/commands-controller.ts
@@ -1,11 +1,19 @@
 import chalk from 'chalk';
+import gitRemoteOriginUrl from 'git-remote-origin-url';
+import CommandGenerateConfig from './generate-config/command-generate-config';
 import CommandInstall from './install/command-install';
+import GitDetector from './install/git-detector/git-detector';
 import ConfigManager from './shared/config/manager/config-manager';
 import CommandUpgrade from './upgrade/command-upgrade';
 
 export default class CommandsController {
+  private _configManager = new ConfigManager();
   private _cmdInstall = new CommandInstall();
-  private _cmdUpgrade = new CommandUpgrade(new ConfigManager());
+  private _cmdUpgrade = new CommandUpgrade(this._configManager);
+  private _cmdGenerateConfig = new CommandGenerateConfig(
+    this._configManager,
+    new GitDetector(gitRemoteOriginUrl),
+  );
 
   public run(argument: string): void {
     if (argument === 'init') {
@@ -13,6 +21,9 @@ export default class CommandsController {
       return;
     } else if (argument === 'upgrade') {
       void this._cmdUpgrade.run();
+      return;
+    } else if (argument === 'generate-config') {
+      void this._cmdGenerateConfig.run();
       return;
     }
 

--- a/src/commands/generate-config/command-generate-config.spec.ts
+++ b/src/commands/generate-config/command-generate-config.spec.ts
@@ -1,0 +1,125 @@
+import * as fs from 'fs';
+import { nanoid } from 'nanoid';
+import path from 'path';
+import { A } from '../../utils/builders/a';
+import { IGitDetector } from '../install/git-detector/git-detector';
+import IConfigRaw from '../shared/config/i-config-raw';
+import { IConfigManager } from '../shared/config/manager/config-manager';
+import { IBuiltPackageJson } from '../shared/i-built-package-json';
+import CommandGenerateConfig from './command-generate-config';
+
+jest.mock('fs');
+
+describe('CommandGenerateConfig class', () => {
+  interface IOptions {
+    packageJson?: IBuiltPackageJson;
+    oysterVersion?: string;
+    gitUrl?: string;
+    gitUrlNoHttp?: string;
+  }
+
+  const setup = (options: IOptions = {}) => {
+    const optionDefaults: IOptions = {
+      packageJson: A.builtPackageJson().build(),
+    };
+
+    const { oysterVersion, gitUrl, gitUrlNoHttp, packageJson } = {
+      ...optionDefaults,
+      ...options,
+    };
+
+    jest.spyOn(fs, 'readFileSync').mockImplementation((filePathRaw: any) => {
+      const filePath = filePathRaw as string;
+      switch (filePath) {
+        case 'package.json':
+          return JSON.stringify(packageJson);
+        case path.resolve(__dirname, '../../../package.json'):
+          return JSON.stringify({ version: oysterVersion });
+      }
+
+      throw new Error(`Unknown path queried: ${filePath}`);
+    });
+
+    spyOn(console, 'log');
+
+    const configManager: IConfigManager = {
+      generate: jest.fn(),
+      read: jest.fn(),
+    };
+
+    const gitDetector: IGitDetector = {
+      getDetails: jest.fn().mockReturnValue(
+        Promise.resolve({
+          gitUrl,
+          gitUrlNoHttp,
+        }),
+      ),
+    };
+
+    return {
+      genConfig: new CommandGenerateConfig(configManager, gitDetector),
+      configManager,
+    };
+  };
+
+  describe('run method', () => {
+    it('should write local package.json contents to equivalent .oyster.json file', async () => {
+      const oysterVersion = '1.2.3';
+      const gitUrl = 'myGitRepo';
+      const gitUrlNoHttp = 'myGitRepoNoHttp';
+
+      const packageJson: IBuiltPackageJson = {
+        author: {
+          email: 'asdf@asdf.com',
+          name: 'Asdf Qwerty',
+          url: 'https://asdf.com',
+        },
+        description: nanoid(),
+        displayName: 'A B',
+        keywords: ['a', 'b', 'c'],
+        name: 'com.a.b',
+        unity: '2019.1',
+      };
+
+      const packageScopeParts = packageJson.name.split('.');
+      packageScopeParts.pop();
+      const packageScope = packageScopeParts.join('.');
+
+      const expectedConfig: IConfigRaw = {
+        packageName: packageJson.name,
+        displayName: packageJson.displayName,
+        description: packageJson.description,
+        oysterVersion,
+        unityVersion: packageJson.unity,
+        packageScope: packageScope,
+        keywords: packageJson.keywords,
+        author: packageJson.author,
+        repo: {
+          gitUrl,
+          gitUrlNoHttp,
+        },
+      };
+
+      const { genConfig, configManager } = setup({
+        packageJson,
+        oysterVersion,
+        gitUrl,
+        gitUrlNoHttp,
+      });
+      await genConfig.run();
+
+      expect(configManager.generate).toHaveBeenCalledWith(expectedConfig);
+    });
+
+    it('should print a success message on completion', async () => {
+      const message = '.oyster.json file successfully created';
+
+      const { genConfig } = setup();
+      await genConfig.run();
+
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining(message),
+      );
+    });
+  });
+});

--- a/src/commands/generate-config/command-generate-config.ts
+++ b/src/commands/generate-config/command-generate-config.ts
@@ -1,0 +1,50 @@
+import chalk from 'chalk';
+import { readFileSync } from 'fs';
+import { IGitDetector } from '../install/git-detector/git-detector';
+import Config from '../shared/config/config';
+import { IConfigManager } from '../shared/config/manager/config-manager';
+import { IBuiltPackageJson } from '../shared/i-built-package-json';
+
+export default class CommandGenerateConfig {
+  constructor(
+    private _configManager: IConfigManager,
+    private _gitDetector: IGitDetector,
+  ) {}
+
+  public async run(): Promise<void> {
+    const startMessage = chalk.blue(
+      'Attempting to generate an .oyster.json file',
+    );
+    console.log(startMessage);
+
+    const packageJsonRaw = readFileSync('package.json').toString();
+    const packageJson = JSON.parse(packageJsonRaw) as IBuiltPackageJson;
+
+    const repo = await this._gitDetector.getDetails();
+
+    const packageScopeParts = packageJson.name.split('.');
+    packageScopeParts.pop();
+    const packageScope = packageScopeParts.join('.');
+
+    const config = new Config({
+      packageName: packageJson.name,
+      packageScope,
+      repo,
+      displayName: packageJson.displayName,
+      description: packageJson.description,
+      unityVersion: packageJson.unity,
+      oysterVersion: '',
+      keywords: packageJson.keywords,
+      author: packageJson.author,
+    });
+
+    config.syncVersion();
+
+    this._configManager.generate(config);
+
+    const successMessage = chalk.green(
+      '.oyster.json file successfully created',
+    );
+    console.log(successMessage);
+  }
+}

--- a/src/commands/install/git-detector/git-detector.ts
+++ b/src/commands/install/git-detector/git-detector.ts
@@ -1,5 +1,4 @@
 export interface IGitDetails {
-  [key: string]: string;
   gitUrlNoHttp: string;
   gitUrl: string;
 }
@@ -9,7 +8,11 @@ export interface IRepoStatus {
   message: string;
 }
 
-export default class GitDetector {
+export interface IGitDetector {
+  getDetails(): Promise<IGitDetails>;
+}
+
+export default class GitDetector implements IGitDetector {
   private readonly _gitRemoteOriginUrl: () => Promise<string>;
 
   constructor(gitRemoteOriginUrl: () => Promise<string>) {

--- a/src/commands/install/package-builder/package-builder_files.spec.ts
+++ b/src/commands/install/package-builder/package-builder_files.spec.ts
@@ -180,7 +180,8 @@ describe('PackageBuilder class', () => {
         const replacements = Object.keys(results).map(
           (key) =>
             ({
-              value: results[key],
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+              value: (results as any)[key] as string,
               key,
             } as IKeyValuePair),
         );

--- a/src/commands/shared/i-built-package-json.ts
+++ b/src/commands/shared/i-built-package-json.ts
@@ -1,0 +1,19 @@
+/**
+ * The package.json file created after oyster init runs. Has several unique key values in it not native to a normal
+ * package.json file
+ */
+export interface IBuiltPackageJson {
+  // Example com.a.b
+  name: string;
+  displayName: string;
+  description: string;
+
+  // Specific version of Unity
+  unity: string;
+  keywords: string[];
+  author: {
+    name: string;
+    email: string;
+    url: string;
+  };
+}

--- a/src/utils/builders/a.ts
+++ b/src/utils/builders/a.ts
@@ -1,5 +1,8 @@
+import { BuilderBuiltPackageJson } from './builder-built-package-json';
 import BuilderConfigRaw from './builder-config-raw';
 
 export const A = {
   configRaw: (): BuilderConfigRaw => new BuilderConfigRaw(),
+  builtPackageJson: (): BuilderBuiltPackageJson =>
+    new BuilderBuiltPackageJson(),
 };

--- a/src/utils/builders/builder-built-package-json.ts
+++ b/src/utils/builders/builder-built-package-json.ts
@@ -1,0 +1,18 @@
+import { IBuiltPackageJson } from '../../commands/shared/i-built-package-json';
+
+export class BuilderBuiltPackageJson {
+  public build(): IBuiltPackageJson {
+    return {
+      author: {
+        email: 'asdf@asdf.com',
+        name: 'Asdf',
+        url: 'asdf.com',
+      },
+      description: 'Desc goes here',
+      displayName: 'A B',
+      keywords: ['a', 'b', 'c'],
+      name: 'com.a.b',
+      unity: '2019.1',
+    };
+  }
+}


### PR DESCRIPTION
Oyster v1.X and v2.0.0 do not have a `.oyster.json` file. This new command will automatically
generate one so the `oyster upgrade` command can still be run. I could have combined this with the
`oyster upgrade` command, but decided against it to prevent bloating the upgrade files.