### PR TITLE
fix(init wizard): leaving the Unity version blank now respects blank …

### DIFF
--- a/src/commands/install/install-questions/install-questions.ts
+++ b/src/commands/install/install-questions/install-questions.ts
@@ -90,11 +90,12 @@ export default class InstallQuestions {
   }
 
   private questionUnityVersion(): Question {
+    const example = chalk.blue('2019.1');
+
     return {
-      message: `Minimum Unity version?. No version indicates all versions of Unity`,
+      message: `Minimum Unity version?. No version indicates all versions of Unity. Example ${example}`,
       name: 'unityVersion',
       type: 'input',
-      default: '2019.1',
     };
   }
 


### PR DESCRIPTION
…values

Accidentally changed it to provide a default value of 2019.1. Reverted the code ot fix the issue.